### PR TITLE
add support for force_deregister and ansible user vars

### DIFF
--- a/images/capi/packer/nutanix/nutanix.json
+++ b/images/capi/packer/nutanix/nutanix.json
@@ -1,4 +1,5 @@
 {
+  "force_deregister": "false",
   "image_name": "",
   "nutanix_cluster_name": "",
   "nutanix_endpoint": "",

--- a/images/capi/packer/nutanix/packer.json
+++ b/images/capi/packer/nutanix/packer.json
@@ -2,6 +2,7 @@
   "builders": [
     {
       "cluster_name": "{{user `nutanix_cluster_name`}}",
+      "force_deregister": "{{user `force_deregister`}}",
       "image_name": "{{user `image_name`}}",
       "memory_mb": "{{user `memory`}}",
       "nutanix_endpoint": "{{user `nutanix_endpoint`}}",
@@ -50,7 +51,9 @@
         "--extra-vars",
         "{{user `ansible_common_vars`}}",
         "--extra-vars",
-        "{{user `ansible_extra_vars`}}"
+        "{{user `ansible_extra_vars`}}",
+        "--extra-vars",
+        "{{user `ansible_user_vars`}}"
       ],
       "playbook_file": "./ansible/node.yml",
       "type": "ansible",
@@ -89,6 +92,7 @@
   "variables": {
     "ansible_common_vars": "",
     "ansible_extra_vars": "ansible_python_interpreter=/usr/bin/python3",
+    "ansible_user_vars": "",
     "build_timestamp": "{{timestamp}}",
     "containerd_sha256": null,
     "containerd_url": "https://github.com/containerd/containerd/releases/download/v{{user `containerd_version`}}/cri-containerd-cni-{{user `containerd_version`}}-linux-amd64.tar.gz",


### PR DESCRIPTION
What this PR does / why we need it:

* Add support for the `force_deregister` property from the Nutanix Packer plugin to make Packer overwrite an existing image
* Add support for `ansible_user_vars` to set Ansible user variables when using custom roles